### PR TITLE
fix: <b>LG</b> shaves $200 off its $500 34-inch curved <b>monitor</b> 

### DIFF
--- a/scraper/price_extractor.py
+++ b/scraper/price_extractor.py
@@ -1,0 +1,63 @@
+import re
+from typing import Optional, List
+
+def extract_price_from_text(text: str) -> Optional[float]:
+    """
+    Extracts the first monetary value from text in a robust way.
+    Handles various currency formats like $1,299.99, $500, €100, £75.50, etc.
+    Returns the first found price (most prominent in text) as a float.
+    """
+    # Comprehensive regex to match prices with optional currency symbols
+    # Matches: $1,234.56, $123, €99.99, £1,200.00, 1000 USD, etc.
+    price_pattern = re.compile(
+        r"""
+        (?<!\d)                                  # Negative lookbehind for digit
+        (?:                                       
+            [$€£¥₹]                               # Currency symbols at start
+            |                                    # or
+            (?=\d)                               # Lookahead for digit (for symbol after)
+        )
+        \s*                                      # Optional whitespace
+        (\d{1,3}(?:,\d{3})*(?:\.\d{2})?          # Group with commas (e.g. 1,000,000.00)
+        |\d+(?:\.\d{2})?)                        # or simple number with optional decimal
+        (?:\s*(?:USD|CAD|EUR|GBP|JPY|CNY))?      # Optional currency code
+        |                                        # OR
+        (\d+(?:\.\d{2,})?)                       # Number with optional decimal (no commas)
+        \s*(?:[$€£¥₹]                             # Currency symbol after
+        |(?:USD|CAD|EUR|GBP|JPY|CNY))
+        """,
+        re.VERBOSE
+    )
+    
+    matches = price_pattern.findall(text)
+    
+    # Flatten the tuple matches from two groups into single list of found prices
+    valid_prices = []
+    for match in matches:
+        # Each match is a tuple of (group1, group2) — take the non-empty one
+        price_str = next(filter(bool, match), "")
+        if price_str:
+            # Remove commas and extract number
+            cleaned = re.sub(r'[^\d.]', '', price_str)
+            try:
+                price = float(cleaned)
+                # Only consider reasonable price range for a monitor
+                if 10 <= price <= 10000:
+                    valid_prices.append(price)
+            except ValueError:
+                continue
+    
+    # Return the first valid price found (most prominent in text)
+    # Avoids picking a lower accessory price over the main product
+    return valid_prices[0] if valid_prices else None
+
+
+def extract_price_from_html(html_content: str) -> Optional[float]:
+    """
+    Extract price from raw HTML content by stripping tags and processing text.
+    """
+    # Simple HTML tag removal
+    text_content = re.sub(r'<[^>]+>', ' ', html_content)
+    # Collapse whitespace
+    text_content = re.sub(r'\s+', ' ', text_content)
+    return extract_price_from_text(text_content)

--- a/tests/test_price_extractor.py
+++ b/tests/test_price_extractor.py
@@ -1,0 +1,37 @@
+import pytest
+from scraper.price_extractor import extract_price_from_text, extract_price_from_html
+
+def test_extract_price_from_text():
+    # Test various formats
+    assert extract_price_from_text("Only $1,299.99 today!") == 1299.99
+    assert extract_price_from_text("Was $500, now $300!") == 500.0
+    assert extract_price_from_text("€99.99 for limited time") == 99.99
+    assert extract_price_from_text("Just £75!") == 75.0
+    assert extract_price_from_text("Save $200 on $500 monitor") == 200.0
+    assert extract_price_from_text("Starting at $100.50") == 100.5
+    assert extract_price_from_text("Buy now for 1500 USD") == 1500.0
+    assert extract_price_from_text("¥1,200 special offer") == 1200.0
+    assert extract_price_from_text("No price here") is None
+    assert extract_price_from_text("Free!") is None
+    assert extract_price_from_text("$5, $10, $1000") == 5.0  # First, not minimum
+
+def test_extract_price_from_html():
+    html = """
+    <div class="product">
+        <h1>LG 34-inch Curved Monitor</h1>
+        <p>Now <span class="price">$499.99</span> was $699.99</p>
+        <p>Save $200 instantly!</p>
+    </div>
+    """
+    assert extract_price_from_html(html) == 499.99
+
+    html_no_match = "<p>No prices listed</p>"
+    assert extract_price_from_html(html_no_match) is None
+
+def test_edge_cases():
+    # Malformed but plausible
+    assert extract_price_from_text("$1,000,000.00 prize") == 1000000.0
+    assert extract_price_from_text("Price: .99 cents") is None  # Not valid
+    assert extract_price_from_text("10,000€ available") == 10000.0
+    assert extract_price_from_text("Only $5 99") is None  # Invalid format
+    assert extract_price_from_text("$123") == 123.0


### PR DESCRIPTION
## PR Description

### Fix Price Extraction for Monitor Article

This PR introduces a robust price extraction function to handle various currency formats, addressing the issue with extracting prices from articles like the one about the LG 34-inch curved monitor.

### Changes

* Added `extract_price_from_text` function in `scraper/price_extractor.py` to extract the first monetary value from a given text.
* Implemented a comprehensive regex pattern to handle different currency formats.

Closes #<number>

Closes #252